### PR TITLE
completions: return matched text too (needed by ipython notebook).

### DIFF
--- a/src/REPL.jl
+++ b/src/REPL.jl
@@ -228,7 +228,7 @@ module REPL
             startpos = prevind(string,startpos)
         end
         println(string[startpos:pos])
-        complete_symbol(string[startpos:pos]), (dotpos+1):pos
+        complete_symbol(string[startpos:pos]), (dotpos+1):pos, string[startpos:pos]
     end
 
     function completeLine(c::REPLCompletionProvider,s)


### PR DESCRIPTION
Return additional information the IPython Notebook needs for completion to work.
