### PR TITLE
Base.banner_color -> Base.banner()

### DIFF
--- a/src/REPL.jl
+++ b/src/REPL.jl
@@ -469,7 +469,7 @@ module REPL
         repl_channel = RemoteRef()
         response_channel = RemoteRef()
         start_repl_backend(repl_channel, response_channel)
-        print(t,Base.banner_color)
+        print(t,Base.banner())
         run_frontend(ReadlineREPL(t),repl_channel,response_channel)
     end
 


### PR DESCRIPTION
After https://github.com/JuliaLang/julia/commit/2af216990aa7e94dc47b2fb4f2e697c7741584ae, the banner should be printed from the `Base.banner()` function instead of the `Base.banner_color` and `Base.banner_plain` strings. Unfortuenatly `have_color` is not set correctly in the new REPL, but that is the next step.
